### PR TITLE
Expanding handling of service key and authentication options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Configure your account details in `~/.steampipe/config/btp.spc`:
 connection "btp" {
   plugin = "ajmaradiaga/btp"
 
-  # You will need to create a service key for the Cloud Management Service. You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis.
+  # You will need to create a service key for the Cloud Management Service. 
+  # You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis.
 
   # URL of the Accounts Service. Required.
   # This can also be set via the `BTP_CIS_ACCOUNTS_SERVICE_URL` environment variable.
@@ -37,10 +38,35 @@ connection "btp" {
   # This can also be set via the `BTP_CIS_ENTITLEMENTS_SERVICE_URL` environment variable.
   # cis_entitlements_service_url = "https://entitlements-service.cfapps.[region].hana.ondemand.com"
 
-  # Access token to communicate with the Cloud Management Service APIs. At the moment only access token is supported. You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis. Required.
+  # Access token to communicate with the Cloud Management Service APIs. Optional.
+  # You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis. 
+  # If no access token is provided, the plugin will try getting an access token using the details provided in cis_client_id, cis_client_secret, cis_token_url, username, password.
   # This can also be set via the `BTP_CIS_ACCESS_TOKEN` environment variable.
   # cis_access_token = "eyJhbGciOiDBNsO0JxFoAaodkDJ3Pmk7cFEsEr5ml5BwNWEafrEjy8Hsxt2mVACpD8B4AIPpRuMoGE71qXGoPcW0vCugceTwN4C3xM8qYmH7DLQrdVIlSX6kydYxnRNjSO8je56ckA4oTC8wm2E2clClPhinDBN6DxHhXlB0eVJnerl4ONpxaH43PYXmHjIsArTuBGK6nCFtApIGN1OvMDPmjHFtOjNgcPCPC5GDXTt5oaB6M2gUrfD5QQVGA7L6yFQlXYPvF6BSyMxpoQXywMUwYA6oqV"
- 
+
+  # A service key (https://help.sap.com/docs/btp/sap-business-technology-platform/creating-service-keys) for the Central Management Service is required to get an access token.  
+  # The values for cis_client_id, cis_client_secret, cis_token_url can be retrieved from it. 
+
+  # OAuth 2.0 Client ID (field in the service key: uua.clientid). Optional.
+  # This can also be set via the `BTP_CIS_CLIENT_ID` environment variable.
+  # cis_client_id = "sb-ut-6y0m0wr1-ai10-1a56-4bv1-52m478h011g6-clone!b017880|cis-central!b14"
+
+  # OAuth 2.0 Client Secret (field in the service key: uua.clientsecret). Optional.
+  # This can also be set via the `BTP_CIS_CLIENT_SECRET` environment variable. Optional.
+  # cis_client_secret = "44s32264-285r-7101-g2n0-g036p1m214us$vm2_UCHAN_mX1FOW0lklBj2-igBsOUG77G-nE1TWsEu="
+
+  # OAuth 2.0 Token URL (field in the service key: uua.url). Optional.
+  # The value in the service key doesn't contain the path, /oauth/token, if not specified the plugin will append it automatically.
+  # This can also be set via the `BTP_CIS_TOKEN_URL` environment variable. Optional.
+  # cis_token_url = "https://[global-account-subdomain].authentication.[region].hana.ondemand.com"
+
+  # User Email used to log in to SAP BTP.
+  # This can also be set via the `BTP_USERNAME` environment variable. Optional.
+  # username = "user@domain.com"
+
+  # User Password used to log in to SAP BTP.
+  # This can also be set via the `BTP_PASSWORD` environment variable. Optional.
+  # password = "My-BTP-Passw0rd"
 }
 ```
 

--- a/btp/connection_config.go
+++ b/btp/connection_config.go
@@ -1,11 +1,6 @@
 package btp
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"os"
-
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 )
 
@@ -15,15 +10,16 @@ type CISServiceKeyConfig struct {
 }
 
 type BTPConfig struct {
-	CISAccountServiceUrl      *string `hcl:"cis_accounts_service_url"`
-	CISEntitlementsServiceUrl *string `hcl:"cis_entitlements_service_url"`
-	CISAccessToken            *string `hcl:"cis_access_token"`
 	Username                  *string `hcl:"username"`
 	Password                  *string `hcl:"password"`
-	CISTokenUrl               *string `hcl:"cis_token_url"`
-	CISClientId               *string `hcl:"cis_client_id"`
-	CISClientSecret           *string `hcl:"cis_client_secret"`
 	CISServiceKeyPath         *string `hcl:"cis_service_key_path"`
+	CISAccessToken            string  `hcl:"cis_access_token,optional"`
+	CISAccountServiceUrl      string  `hcl:"cis_accounts_service_url,optional"`
+	CISEntitlementsServiceUrl string  `hcl:"cis_entitlements_service_url,optional"`
+	CISEventsServiceUrl       string  `hcl:"cis_events_service_url,optional"`
+	CISTokenUrl               string  `hcl:"cis_token_url,optional"`
+	CISClientId               string  `hcl:"cis_client_id,optional"`
+	CISClientSecret           string  `hcl:"cis_client_secret,optional"`
 }
 
 func ConfigInstance() interface{} {
@@ -37,25 +33,5 @@ func GetConfig(connection *plugin.Connection) BTPConfig {
 	}
 	config, _ := connection.Config.(BTPConfig)
 
-	// Reads the JSON file in cis_service_key_path and sets the value of cis_client_id and cis_client_secret
-	if config.CISServiceKeyPath != nil {
-		jsonFile, err := os.Open(*config.CISServiceKeyPath)
-
-		if err != nil {
-			fmt.Println(err)
-		}
-		defer jsonFile.Close()
-
-		data, err := io.ReadAll(jsonFile)
-		if err != nil {
-			fmt.Println(err)
-		}
-
-		var serviceKey CISServiceKeyConfig
-		json.Unmarshal(data, &serviceKey)
-
-		config.CISEventsServiceUrl = serviceKey.Endpoints["events"]
-
-	}
 	return config
 }

--- a/btp/connection_config.go
+++ b/btp/connection_config.go
@@ -1,11 +1,6 @@
 package btp
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"os"
-
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 )
 
@@ -38,28 +33,5 @@ func GetConfig(connection *plugin.Connection) BTPConfig {
 	}
 	config, _ := connection.Config.(BTPConfig)
 
-<<<<<<< HEAD
-=======
-	// Reads the JSON file in cis_service_key_path and sets the value of cis_client_id and cis_client_secret
-	if config.CISServiceKeyPath != nil {
-		jsonFile, err := os.Open(*config.CISServiceKeyPath)
-
-		if err != nil {
-			fmt.Println(err)
-		}
-		defer jsonFile.Close()
-
-		data, err := io.ReadAll(jsonFile)
-		if err != nil {
-			fmt.Println(err)
-		}
-
-		var serviceKey CISServiceKeyConfig
-		json.Unmarshal(data, &serviceKey)
-
-		config.CISEventsServiceUrl = serviceKey.Endpoints["events"]
-
-	}
->>>>>>> 2f53a7e (Including additional config supported)
 	return config
 }

--- a/btp/connection_config.go
+++ b/btp/connection_config.go
@@ -17,7 +17,13 @@ type CISServiceKeyConfig struct {
 type BTPConfig struct {
 	CISAccountServiceUrl      *string `hcl:"cis_accounts_service_url"`
 	CISEntitlementsServiceUrl *string `hcl:"cis_entitlements_service_url"`
-	AccessToken               *string `hcl:"cis_access_token"`
+	CISAccessToken            *string `hcl:"cis_access_token"`
+	Username                  *string `hcl:"username"`
+	Password                  *string `hcl:"password"`
+	CISTokenUrl               *string `hcl:"cis_token_url"`
+	CISClientId               *string `hcl:"cis_client_id"`
+	CISClientSecret           *string `hcl:"cis_client_secret"`
+	CISServiceKeyPath         *string `hcl:"cis_service_key_path"`
 }
 
 func ConfigInstance() interface{} {

--- a/btp/connection_config.go
+++ b/btp/connection_config.go
@@ -27,54 +27,6 @@ type BTPConfig struct {
 	CISClientSecret           string  `hcl:"cis_client_secret,optional"`
 }
 
-var ConfigSchema = map[string]*schema.Attribute{
-	"cis_accounts_service_url": {
-		Type: schema.TypeString,
-	},
-
-	"cis_entitlements_service_url": {
-		Type: schema.TypeString,
-	},
-
-	"cis_access_token": {
-		Type:     schema.TypeString,
-		Required: false,
-	},
-
-	// Username and password to be used in combination with cis_token_url, cis_client_id and cis_client_secret when retrieving access token
-	"username": {
-		Type:     schema.TypeString,
-		Required: false,
-	},
-
-	"password": {
-		Type:     schema.TypeString,
-		Required: false,
-	},
-
-	"cis_token_url": {
-		Type:     schema.TypeString,
-		Required: false,
-	},
-
-	"cis_client_id": {
-		Type:     schema.TypeString,
-		Required: false,
-	},
-
-	"cis_client_secret": {
-		Type:     schema.TypeString,
-		Required: false,
-	},
-
-	"cis_service_key_path": {
-		Type:     schema.TypeString,
-		Required: false,
-	},
->>>>>>> a7118c7 (Including additional config supported)
->>>>>>> 2f53a7e (Including additional config supported)
-}
-
 func ConfigInstance() interface{} {
 	return &BTPConfig{}
 }

--- a/btp/connection_config.go
+++ b/btp/connection_config.go
@@ -1,8 +1,18 @@
 package btp
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 )
+
+type CISServiceKeyConfig struct {
+	Endpoints map[string]string `json:"endpoints"`
+	Uaa       map[string]string `json:"uaa"`
+}
 
 type BTPConfig struct {
 	CISAccountServiceUrl      *string `hcl:"cis_accounts_service_url"`
@@ -20,5 +30,26 @@ func GetConfig(connection *plugin.Connection) BTPConfig {
 		return BTPConfig{}
 	}
 	config, _ := connection.Config.(BTPConfig)
+
+	// Reads the JSON file in cis_service_key_path and sets the value of cis_client_id and cis_client_secret
+	if config.CISServiceKeyPath != nil {
+		jsonFile, err := os.Open(*config.CISServiceKeyPath)
+
+		if err != nil {
+			fmt.Println(err)
+		}
+		defer jsonFile.Close()
+
+		data, err := io.ReadAll(jsonFile)
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		var serviceKey CISServiceKeyConfig
+		json.Unmarshal(data, &serviceKey)
+
+		config.CISEventsServiceUrl = serviceKey.Endpoints["events"]
+
+	}
 	return config
 }

--- a/btp/connection_config.go
+++ b/btp/connection_config.go
@@ -1,6 +1,11 @@
 package btp
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 )
 
@@ -22,6 +27,54 @@ type BTPConfig struct {
 	CISClientSecret           string  `hcl:"cis_client_secret,optional"`
 }
 
+var ConfigSchema = map[string]*schema.Attribute{
+	"cis_accounts_service_url": {
+		Type: schema.TypeString,
+	},
+
+	"cis_entitlements_service_url": {
+		Type: schema.TypeString,
+	},
+
+	"cis_access_token": {
+		Type:     schema.TypeString,
+		Required: false,
+	},
+
+	// Username and password to be used in combination with cis_token_url, cis_client_id and cis_client_secret when retrieving access token
+	"username": {
+		Type:     schema.TypeString,
+		Required: false,
+	},
+
+	"password": {
+		Type:     schema.TypeString,
+		Required: false,
+	},
+
+	"cis_token_url": {
+		Type:     schema.TypeString,
+		Required: false,
+	},
+
+	"cis_client_id": {
+		Type:     schema.TypeString,
+		Required: false,
+	},
+
+	"cis_client_secret": {
+		Type:     schema.TypeString,
+		Required: false,
+	},
+
+	"cis_service_key_path": {
+		Type:     schema.TypeString,
+		Required: false,
+	},
+>>>>>>> a7118c7 (Including additional config supported)
+>>>>>>> 2f53a7e (Including additional config supported)
+}
+
 func ConfigInstance() interface{} {
 	return &BTPConfig{}
 }
@@ -33,5 +86,28 @@ func GetConfig(connection *plugin.Connection) BTPConfig {
 	}
 	config, _ := connection.Config.(BTPConfig)
 
+<<<<<<< HEAD
+=======
+	// Reads the JSON file in cis_service_key_path and sets the value of cis_client_id and cis_client_secret
+	if config.CISServiceKeyPath != nil {
+		jsonFile, err := os.Open(*config.CISServiceKeyPath)
+
+		if err != nil {
+			fmt.Println(err)
+		}
+		defer jsonFile.Close()
+
+		data, err := io.ReadAll(jsonFile)
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		var serviceKey CISServiceKeyConfig
+		json.Unmarshal(data, &serviceKey)
+
+		config.CISEventsServiceUrl = serviceKey.Endpoints["events"]
+
+	}
+>>>>>>> 2f53a7e (Including additional config supported)
 	return config
 }

--- a/btp/table_btp_accounts_directory.go
+++ b/btp/table_btp_accounts_directory.go
@@ -50,7 +50,7 @@ func getDirectory(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 
 	logger.Trace("Hydrating list subaccounts")
 
-	btpClient, err := NewBTPClient(nil, d.Connection)
+	btpClient, err := NewBTPClient(nil, d)
 	if err != nil {
 		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "connection_error", err)
 		return nil, err

--- a/btp/table_btp_accounts_directory.go
+++ b/btp/table_btp_accounts_directory.go
@@ -50,9 +50,9 @@ func getDirectory(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 
 	logger.Trace("Hydrating list subaccounts")
 
-	btpClient, err := NewBTPClient(nil, d)
+	btpClient, err := NewBTPClient(nil, ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "connection_error", err)
+		logger.Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "connection_error", err)
 		return nil, err
 	}
 
@@ -73,7 +73,7 @@ func getDirectory(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 	body, err := btpClient.Get(ctx, AccountsService, path, nil, queryStrings)
 
 	if err != nil {
-		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
+		logger.Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
 		return nil, err
 	}
 
@@ -86,7 +86,7 @@ func getDirectory(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 	logger.Warn(fnName, "err", err)
 
 	if err != nil {
-		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
+		logger.Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
 		return nil, err
 	}
 

--- a/btp/table_btp_accounts_global_account.go
+++ b/btp/table_btp_accounts_global_account.go
@@ -46,10 +46,10 @@ func getGlobalAccount(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	logger := plugin.Logger(ctx)
 	logger.Trace("Hydrating Global Account")
 
-	btpClient, err := NewBTPClient(nil, d)
+	btpClient, err := NewBTPClient(nil, ctx, d)
 
 	if err != nil {
-		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "connection_error", err)
+		logger.Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "connection_error", err)
 		return nil, err
 	}
 
@@ -62,7 +62,7 @@ func getGlobalAccount(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	body, err := btpClient.Get(ctx, AccountsService, globalAccountsPath, nil, queryStrings)
 
 	if err != nil {
-		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
+		logger.Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
 		return nil, err
 	}
 
@@ -75,7 +75,7 @@ func getGlobalAccount(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	logger.Debug("getGlobalAccount", "err", err)
 
 	if err != nil {
-		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
+		logger.Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
 		return nil, err
 	}
 

--- a/btp/table_btp_accounts_global_account.go
+++ b/btp/table_btp_accounts_global_account.go
@@ -46,7 +46,7 @@ func getGlobalAccount(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	logger := plugin.Logger(ctx)
 	logger.Trace("Hydrating Global Account")
 
-	btpClient, err := NewBTPClient(nil, d.Connection)
+	btpClient, err := NewBTPClient(nil, d)
 
 	if err != nil {
 		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "connection_error", err)

--- a/btp/table_btp_accounts_subaccount.go
+++ b/btp/table_btp_accounts_subaccount.go
@@ -55,9 +55,9 @@ func listSubaccounts(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	logger.Trace("Hydrating list subaccounts")
 
 	// conn, err := connect(ctx, d)
-	btpClient, err := NewBTPClient(nil, d)
+	btpClient, err := NewBTPClient(nil, ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "connection_error", err)
+		logger.Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "connection_error", err)
 		return nil, err
 	}
 
@@ -65,7 +65,7 @@ func listSubaccounts(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	body, err := btpClient.Get(ctx, AccountsService, subAccountsPath, nil, nil)
 
 	if err != nil {
-		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
+		logger.Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
 		return nil, err
 	}
 
@@ -80,7 +80,7 @@ func listSubaccounts(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	logger.Debug("listAccount", "err", err)
 
 	if err != nil {
-		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
+		logger.Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
 		return nil, err
 	}
 
@@ -98,7 +98,7 @@ func getSubaccount(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 	logger := plugin.Logger(ctx)
 	logger.Trace("Hydrating get subaccount")
 
-	btpClient, err := NewBTPClient(nil, d)
+	btpClient, err := NewBTPClient(nil, ctx, d)
 	if err != nil {
 		return nil, err
 	}

--- a/btp/table_btp_accounts_subaccount.go
+++ b/btp/table_btp_accounts_subaccount.go
@@ -55,7 +55,7 @@ func listSubaccounts(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	logger.Trace("Hydrating list subaccounts")
 
 	// conn, err := connect(ctx, d)
-	btpClient, err := NewBTPClient(nil, d.Connection)
+	btpClient, err := NewBTPClient(nil, d)
 	if err != nil {
 		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "connection_error", err)
 		return nil, err
@@ -98,7 +98,7 @@ func getSubaccount(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 	logger := plugin.Logger(ctx)
 	logger.Trace("Hydrating get subaccount")
 
-	btpClient, err := NewBTPClient(nil, d.Connection)
+	btpClient, err := NewBTPClient(nil, d)
 	if err != nil {
 		return nil, err
 	}

--- a/btp/table_btp_entitlements_assignment.go
+++ b/btp/table_btp_entitlements_assignment.go
@@ -40,7 +40,7 @@ func listGlobalAccountAssignments(ctx context.Context, d *plugin.QueryData, h *p
 
 	logger.Trace("Hydrating list of assignments")
 
-	btpClient, err := NewBTPClient(nil, d.Connection)
+	btpClient, err := NewBTPClient(nil, d)
 	if err != nil {
 		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "connection_error", err)
 		return nil, err

--- a/btp/table_btp_entitlements_assignment.go
+++ b/btp/table_btp_entitlements_assignment.go
@@ -40,9 +40,9 @@ func listGlobalAccountAssignments(ctx context.Context, d *plugin.QueryData, h *p
 
 	logger.Trace("Hydrating list of assignments")
 
-	btpClient, err := NewBTPClient(nil, d)
+	btpClient, err := NewBTPClient(nil, ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "connection_error", err)
+		logger.Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "connection_error", err)
 		return nil, err
 	}
 
@@ -62,7 +62,7 @@ func listGlobalAccountAssignments(ctx context.Context, d *plugin.QueryData, h *p
 	body, err := btpClient.Get(ctx, EntitlementService, path, nil, queryStrings)
 
 	if err != nil {
-		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
+		logger.Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
 		return nil, err
 	}
 
@@ -77,7 +77,7 @@ func listGlobalAccountAssignments(ctx context.Context, d *plugin.QueryData, h *p
 	logger.Warn(fnName, "err", err)
 
 	if err != nil {
-		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
+		logger.Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
 		return nil, err
 	}
 

--- a/btp/table_btp_entitlements_datacenter.go
+++ b/btp/table_btp_entitlements_datacenter.go
@@ -44,9 +44,9 @@ func listDataCenters(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 
 	logger.Trace("Hydrating list allowed data centers")
 
-	btpClient, err := NewBTPClient(nil, d)
+	btpClient, err := NewBTPClient(nil, ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "connection_error", err)
+		logger.Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "connection_error", err)
 		return nil, err
 	}
 
@@ -69,7 +69,7 @@ func listDataCenters(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	body, err := btpClient.Get(ctx, EntitlementService, path, nil, queryStrings)
 
 	if err != nil {
-		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
+		logger.Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
 		return nil, err
 	}
 
@@ -84,7 +84,7 @@ func listDataCenters(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	logger.Warn(fnName, "err", err)
 
 	if err != nil {
-		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
+		logger.Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "api_error", err)
 		return nil, err
 	}
 

--- a/btp/table_btp_entitlements_datacenter.go
+++ b/btp/table_btp_entitlements_datacenter.go
@@ -44,7 +44,7 @@ func listDataCenters(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 
 	logger.Trace("Hydrating list allowed data centers")
 
-	btpClient, err := NewBTPClient(nil, d.Connection)
+	btpClient, err := NewBTPClient(nil, d)
 	if err != nil {
 		plugin.Logger(ctx).Error(fmt.Sprintf("%s.%s", d.Table.Name, fnName), "connection_error", err)
 		return nil, err

--- a/btp/types.go
+++ b/btp/types.go
@@ -1,5 +1,15 @@
 package btp
 
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	IDToken      string `json:"id_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+	Scope        string `json:"scope"`
+	JTI          string `json:"jti"`
+}
+
 type CustomProperty struct {
 	AccountGUID string `json:"accountGUID"`
 	Key         string `json:"key"`

--- a/btp/utils.go
+++ b/btp/utils.go
@@ -46,6 +46,7 @@ type (
 // NewBTPClient creates new SAP BTP API client
 func NewBTPClient(httpClient *http.Client, ctx context.Context, d *plugin.QueryData) (*BTPClient, error) {
 
+	fnName := "NewBTPClient"
 	debugFormat := "BTPClient.NewBTPClient: %s"
 	logger := plugin.Logger(ctx)
 
@@ -71,7 +72,7 @@ func NewBTPClient(httpClient *http.Client, ctx context.Context, d *plugin.QueryD
 
 		logger.Debug(fmt.Sprintf(debugFormat, "connection is not nil"))
 
-		logger.Debug(fmt.Sprintf(debugFormat, config))
+		logger.Debug(fmt.Sprintf(debugFormat, config.CISServiceKeyPath))
 
 		CISServiceKeyPath := prioritiseEnvVar(os.Getenv("BTP_CIS_SERVICE_KEY_PATH"), config.CISServiceKeyPath)
 
@@ -101,7 +102,15 @@ func NewBTPClient(httpClient *http.Client, ctx context.Context, d *plugin.QueryD
 			logger.Debug(fmt.Sprintf(debugFormat, string(data)))
 
 			var serviceKey CISServiceKeyConfig
-			json.Unmarshal(data, &serviceKey)
+			err = json.Unmarshal(data, &serviceKey)
+
+			logger.Warn(fnName, "data", data)
+			logger.Warn(fnName, "err", err)
+
+			if err != nil {
+				logger.Error(fnName, "service_key_error", err)
+				return nil, err
+			}
 
 			// Setting the config values from the service key
 			config.CISAccountServiceUrl = prioritiseConfigVar(&config.CISAccountServiceUrl, serviceKey.Endpoints["accounts_service_url"])

--- a/config/btp.spc
+++ b/config/btp.spc
@@ -1,7 +1,8 @@
 connection "btp" {
   plugin = "ajmaradiaga/btp"
 
-  # You will need to create a service key for the Cloud Management Service. You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis.
+  # You will need to create a service key for the Cloud Management Service. 
+  # You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis.
 
   # URL of the Accounts Service. Required.
   # This can also be set via the `BTP_CIS_ACCOUNTS_SERVICE_URL` environment variable.
@@ -11,8 +12,33 @@ connection "btp" {
   # This can also be set via the `BTP_CIS_ENTITLEMENTS_SERVICE_URL` environment variable.
   # cis_entitlements_service_url = "https://entitlements-service.cfapps.[region].hana.ondemand.com"
 
-  # Access token to communicate with the Cloud Management Service APIs. At the moment only access token is supported. You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis. Required.
+  # Access token to communicate with the Cloud Management Service APIs. Optional.
+  # You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis. 
+  # If no access token is provided, the plugin will try getting an access token using the details provided in cis_client_id, cis_client_secret, cis_token_url, username, password.
   # This can also be set via the `BTP_CIS_ACCESS_TOKEN` environment variable.
   # cis_access_token = "eyJhbGciOiDBNsO0JxFoAaodkDJ3Pmk7cFEsEr5ml5BwNWEafrEjy8Hsxt2mVACpD8B4AIPpRuMoGE71qXGoPcW0vCugceTwN4C3xM8qYmH7DLQrdVIlSX6kydYxnRNjSO8je56ckA4oTC8wm2E2clClPhinDBN6DxHhXlB0eVJnerl4ONpxaH43PYXmHjIsArTuBGK6nCFtApIGN1OvMDPmjHFtOjNgcPCPC5GDXTt5oaB6M2gUrfD5QQVGA7L6yFQlXYPvF6BSyMxpoQXywMUwYA6oqV"
- 
+
+  # A service key (https://help.sap.com/docs/btp/sap-business-technology-platform/creating-service-keys) for the Central Management Service is required to get an access token.  
+  # The values for cis_client_id, cis_client_secret, cis_token_url can be retrieved from it. 
+
+  # OAuth 2.0 Client ID (field in the service key: uua.clientid). Optional.
+  # This can also be set via the `BTP_CIS_CLIENT_ID` environment variable.
+  # cis_client_id = "sb-ut-6y0m0wr1-ai10-1a56-4bv1-52m478h011g6-clone!b017880|cis-central!b14"
+
+  # OAuth 2.0 Client Secret (field in the service key: uua.clientsecret). Optional.
+  # This can also be set via the `BTP_CIS_CLIENT_SECRET` environment variable. Optional.
+  # cis_client_secret = "44s32264-285r-7101-g2n0-g036p1m214us$vm2_UCHAN_mX1FOW0lklBj2-igBsOUG77G-nE1TWsEu="
+
+  # OAuth 2.0 Token URL (field in the service key: uua.url). Optional.
+  # The value in the service key doesn't contain the path, /oauth/token, if not specified the plugin will append it automatically.
+  # This can also be set via the `BTP_CIS_TOKEN_URL` environment variable. Optional.
+  # cis_token_url = "https://[global-account-subdomain].authentication.[region].hana.ondemand.com"
+
+  # User Email used to log in to SAP BTP.
+  # This can also be set via the `BTP_USERNAME` environment variable. Optional.
+  # username = "user@domain.com"
+
+  # User Password used to log in to SAP BTP.
+  # This can also be set via the `BTP_PASSWORD` environment variable. Optional.
+  # password = "My-BTP-Passw0rd"
 }

--- a/config/btp.spc
+++ b/config/btp.spc
@@ -43,4 +43,15 @@ connection "btp" {
   # The value in the service key doesn't contain the path, /oauth/token, if not specified the plugin will append it automatically.
   # This can also be set via the `BTP_CIS_TOKEN_URL` environment variable. Optional.
   # cis_token_url = "https://[global-account-subdomain].authentication.[region].hana.ondemand.com"
+<<<<<<< HEAD
+=======
+
+  # User Email used to log in to SAP BTP.
+  # This can also be set via the `BTP_USERNAME` environment variable. Optional.
+  # username = "user@domain.com"
+
+  # User Password used to log in to SAP BTP.
+  # This can also be set via the `BTP_PASSWORD` environment variable. Optional.
+  # password = "My-BTP-Passw0rd"
+>>>>>>> 2f53a7e (Including additional config supported)
 }

--- a/config/btp.spc
+++ b/config/btp.spc
@@ -1,14 +1,24 @@
 connection "btp" {
   plugin = "ajmaradiaga/btp"
 
-  # You will need to create a service key for the Cloud Management Service. 
-  # You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis.
+  # User email used to log in to SAP BTP. Required.
+  # This can also be set via the `BTP_USERNAME` environment variable.
+  # username = "user@domain.com"
 
-  # URL of the Accounts Service. Required.
+  # User password used to log in to SAP BTP. Required.
+  # This can also be set via the `BTP_PASSWORD` environment variable.
+  # password = "My-BTP-Passw0rd"
+
+  # You will need to create a service key for the Cloud Management Service. Required.
+  # You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis.
+  # This can also be set via the `BTP_CIS_SERVICE_KEY_PATH` environment variable. Required.
+  # cis_service_key_path = "~/service_keys/cis_global.json"
+
+  # URL of the Accounts Service. Optional.
   # This can also be set via the `BTP_CIS_ACCOUNTS_SERVICE_URL` environment variable.
   # cis_accounts_service_url = "https://accounts-service.cfapps.[region].hana.ondemand.com"
   
-  # URL of the Entitlements Service. Required.
+  # URL of the Entitlements Service. Optional.
   # This can also be set via the `BTP_CIS_ENTITLEMENTS_SERVICE_URL` environment variable.
   # cis_entitlements_service_url = "https://entitlements-service.cfapps.[region].hana.ondemand.com"
 
@@ -33,12 +43,4 @@ connection "btp" {
   # The value in the service key doesn't contain the path, /oauth/token, if not specified the plugin will append it automatically.
   # This can also be set via the `BTP_CIS_TOKEN_URL` environment variable. Optional.
   # cis_token_url = "https://[global-account-subdomain].authentication.[region].hana.ondemand.com"
-
-  # User Email used to log in to SAP BTP.
-  # This can also be set via the `BTP_USERNAME` environment variable. Optional.
-  # username = "user@domain.com"
-
-  # User Password used to log in to SAP BTP.
-  # This can also be set via the `BTP_PASSWORD` environment variable. Optional.
-  # password = "My-BTP-Passw0rd"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,11 @@ steampipe plugin install ajmaradiaga/btp
 | Credentials | You will need to create a service key for the Cloud Management Service. You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis.                                                                |                                                               |
 | Permissions | Create a [Cloud Management Service with a `Central` service plan](https://discovery-center.cloud.sap/serviceCatalog/cloud-management-service?region=all&tab=service_plan) to manage your global account, subaccounts, directories, and entitlements.  |
 | Radius | Each connection represents a single SAP BTP account. |
+<<<<<<< HEAD
 | Resolution  | You can authenticate by providing an access token or the details of a service key in the connection config file. The plugin prioritises an access token if one is provided.<br/><ol><li>The access token can be provided via environment variables or in the connection config file. <br/><ol><li>Access token specified in environment variables, e.g., `BTP_CIS_ACCESS_TOKEN`.</li><li>Access token explicitly set in a steampipe config file (`~/.steampipe/config/btp.spc`)</li></ol><li>Service key details can be provided by specifying a file path to the service key via environment variable (`BTP_CIS_SERVICE_KEY_PATH`) or in the connection config file (`cis_service_key_path`).<ol><li>Service key details provided in environment variables, e.g., `BTP_CIS_CLIENT_ID`, `BTP_CIS_CLIENT_SECRET`, `BTP_CIS_TOKEN_URL` will be prioritised over the values in the config file.</li><li>Service key details explicitly set in a steampipe config file (`~/.steampipe/config/btp.spc`)</li></ol></ol><br/>Generally the plugin prioritises environment variables then values in the config file and lastly values in the service key file. |
+=======
+| Resolution  | You can authenticate by providing an access token or the details of a service key in the connection config file. The plugin prioritises an access token if one is provided.<br/><ol><li>The access token can be provided via environment variables or in the connection config file. <br/><ol><li>Access token specified in environment variables, e.g., `BTP_CIS_ACCESS_TOKEN`.</li><li>Access token explicitly set in a steampipe config file (`~/.steampipe/config/btp.spc`)</li></ol><li>Service key details can be provided via environment variables or in the connection config file.<ol><li>Service key details provided in environment variables, e.g., `BTP_CIS_CLIENT_ID`, `BTP_CIS_CLIENT_SECRET`, `BTP_CIS_TOKEN_URL`.</li><li>Service key details explicitly set in a steampipe config file (`~/.steampipe/config/btp.spc`)</li></ol></ol> |
+>>>>>>> 2f53a7e (Including additional config supported)
 
 ### Configuration
 
@@ -112,6 +116,17 @@ connection "btp" {
   # The value in the service key doesn't contain the path, /oauth/token, if not specified the plugin will append it automatically.
   # This can also be set via the `BTP_CIS_TOKEN_URL` environment variable. Optional.
   # cis_token_url = "https://[global-account-subdomain].authentication.[region].hana.ondemand.com"
+<<<<<<< HEAD
+=======
+
+  # User Email used to log in to SAP BTP.
+  # This can also be set via the `BTP_USERNAME` environment variable. Optional.
+  # username = "user@domain.com"
+
+  # User Password used to log in to SAP BTP.
+  # This can also be set via the `BTP_PASSWORD` environment variable. Optional.
+  # password = "My-BTP-Passw0rd"
+>>>>>>> 2f53a7e (Including additional config supported)
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ steampipe plugin install ajmaradiaga/btp
 | Credentials | You will need to create a service key for the Cloud Management Service. You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis.                                                                |                                                               |
 | Permissions | Create a [Cloud Management Service with a `Central` service plan](https://discovery-center.cloud.sap/serviceCatalog/cloud-management-service?region=all&tab=service_plan) to manage your global account, subaccounts, directories, and entitlements.  |
 | Radius | Each connection represents a single SAP BTP account. |
-| Resolution  | You can authenticate by providing an access token or the details of a service key in the connection config file. The plugin prioritises an access token if one is provided.<br/><ol><li>The access token can be provided via environment variables or in the connection config file. <br/><ol><li>Access token specified in environment variables, e.g., `BTP_CIS_ACCESS_TOKEN`.</li><li>Access token explicitly set in a steampipe config file (`~/.steampipe/config/btp.spc`)</li></ol><li>Service key details can be provided via environment variables or in the connection config file.<ol><li>Service key details provided in environment variables, e.g., `BTP_CIS_CLIENT_ID`, `BTP_CIS_CLIENT_SECRET`, `BTP_CIS_TOKEN_URL`.</li><li>Service key details explicitly set in a steampipe config file (`~/.steampipe/config/btp.spc`)</li></ol></ol> |
+| Resolution  | You can authenticate by providing an access token or the details of a service key in the connection config file. The plugin prioritises an access token if one is provided.<br/><ol><li>The access token can be provided via environment variables or in the connection config file. <br/><ol><li>Access token specified in environment variables, e.g., `BTP_CIS_ACCESS_TOKEN`.</li><li>Access token explicitly set in a steampipe config file (`~/.steampipe/config/btp.spc`)</li></ol><li>Service key details can be provided by specifying a file path to the service key via environment variable (`BTP_CIS_SERVICE_KEY_PATH`) or in the connection config file (`cis_service_key_path`).<ol><li>Service key details provided in environment variables, e.g., `BTP_CIS_CLIENT_ID`, `BTP_CIS_CLIENT_SECRET`, `BTP_CIS_TOKEN_URL` will be prioritised over the values in the config file.</li><li>Service key details explicitly set in a steampipe config file (`~/.steampipe/config/btp.spc`)</li></ol></ol><br/>Generally the plugin prioritises environment variables then values in the config file and lastly values in the service key file. |
 
 ### Configuration
 
@@ -70,14 +70,24 @@ Configure your account details in `~/.steampipe/config/btp.spc`:
 connection "btp" {
   plugin = "ajmaradiaga/btp"
 
-  # You will need to create a service key for the Cloud Management Service. 
-  # You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis.
+  # User email used to log in to SAP BTP. Required.
+  # This can also be set via the `BTP_USERNAME` environment variable.
+  # username = "user@domain.com"
 
-  # URL of the Accounts Service. Required.
+  # User password used to log in to SAP BTP. Required.
+  # This can also be set via the `BTP_PASSWORD` environment variable.
+  # password = "My-BTP-Passw0rd"
+
+  # You will need to create a service key for the Cloud Management Service. Required.
+  # You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis.
+  # This can also be set via the `BTP_CIS_SERVICE_KEY_PATH` environment variable. Required.
+  # cis_service_key_path = "~/service_keys/cis_global.json"
+
+  # URL of the Accounts Service. Optional.
   # This can also be set via the `BTP_CIS_ACCOUNTS_SERVICE_URL` environment variable.
   # cis_accounts_service_url = "https://accounts-service.cfapps.[region].hana.ondemand.com"
   
-  # URL of the Entitlements Service. Required.
+  # URL of the Entitlements Service. Optional.
   # This can also be set via the `BTP_CIS_ENTITLEMENTS_SERVICE_URL` environment variable.
   # cis_entitlements_service_url = "https://entitlements-service.cfapps.[region].hana.ondemand.com"
 
@@ -102,20 +112,15 @@ connection "btp" {
   # The value in the service key doesn't contain the path, /oauth/token, if not specified the plugin will append it automatically.
   # This can also be set via the `BTP_CIS_TOKEN_URL` environment variable. Optional.
   # cis_token_url = "https://[global-account-subdomain].authentication.[region].hana.ondemand.com"
-
-  # User Email used to log in to SAP BTP.
-  # This can also be set via the `BTP_USERNAME` environment variable. Optional.
-  # username = "user@domain.com"
-
-  # User Password used to log in to SAP BTP.
-  # This can also be set via the `BTP_PASSWORD` environment variable. Optional.
-  # password = "My-BTP-Passw0rd"
 }
 ```
 
 Alternatively, you can also use the environment variables specified below:
 
 ```sh
+export BTP_USERNAME=user@domain.com
+export BTP_PASSWORD=My-BTP-Passw0rd
+export BTP_CIS_SERVICE_KEY_PATH=~/service_keys/cis_global.json
 export BTP_CIS_ACCOUNTS_SERVICE_URL=https://accounts-service.cfapps.eu10.hana.ondemand.com
 export BTP_CIS_ENTITLEMENTS_SERVICE_URL=https://entitlements-service.cfapps.eu10.hana.ondemand.com
 export BTP_CIS_ACCESS_TOKEN=eyJhbGciOiDBNsO0JxFoAaodkDJ3Pmk7cFEsEr5ml5BwNWEafrEjy8Hsxt2mVACpD8B4AIPpRuMoGE71qXGoPcW0vCugceTwN4C3xM8qYmH7DLQ

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ steampipe plugin install ajmaradiaga/btp
 | Credentials | You will need to create a service key for the Cloud Management Service. You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis.                                                                |                                                               |
 | Permissions | Create a [Cloud Management Service with a `Central` service plan](https://discovery-center.cloud.sap/serviceCatalog/cloud-management-service?region=all&tab=service_plan) to manage your global account, subaccounts, directories, and entitlements.  |
 | Radius | Each connection represents a single SAP BTP account. |
-| Resolution  | 1. Credentials specified in environment variables, e.g., `BTP_CIS_ACCESS_TOKEN`.<br />2. Credentials explicitly set in a steampipe config file (`~/.steampipe/config/btp.spc`) |
+| Resolution  | You can authenticate by providing an access token or the details of a service key in the connection config file. The plugin prioritises an access token if one is provided.<br/><ol><li>The access token can be provided via environment variables or in the connection config file. <br/><ol><li>Access token specified in environment variables, e.g., `BTP_CIS_ACCESS_TOKEN`.</li><li>Access token explicitly set in a steampipe config file (`~/.steampipe/config/btp.spc`)</li></ol><li>Service key details can be provided via environment variables or in the connection config file.<ol><li>Service key details provided in environment variables, e.g., `BTP_CIS_CLIENT_ID`, `BTP_CIS_CLIENT_SECRET`, `BTP_CIS_TOKEN_URL`.</li><li>Service key details explicitly set in a steampipe config file (`~/.steampipe/config/btp.spc`)</li></ol></ol> |
 
 ### Configuration
 
@@ -70,7 +70,8 @@ Configure your account details in `~/.steampipe/config/btp.spc`:
 connection "btp" {
   plugin = "ajmaradiaga/btp"
 
-  # You will need to create a service key for the Cloud Management Service. You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis.
+  # You will need to create a service key for the Cloud Management Service. 
+  # You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis.
 
   # URL of the Accounts Service. Required.
   # This can also be set via the `BTP_CIS_ACCOUNTS_SERVICE_URL` environment variable.
@@ -80,10 +81,35 @@ connection "btp" {
   # This can also be set via the `BTP_CIS_ENTITLEMENTS_SERVICE_URL` environment variable.
   # cis_entitlements_service_url = "https://entitlements-service.cfapps.[region].hana.ondemand.com"
 
-  # Access token to communicate with the Cloud Management Service APIs. At the moment only access token is supported. You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis. Required.
+  # Access token to communicate with the Cloud Management Service APIs. Optional.
+  # You can get the instructions on how to get an access token for the SAP Cloud Management Service APIs here: https://help.sap.com/docs/btp/sap-business-technology-platform/getting-access-token-for-sap-cloud-management-service-apis. 
+  # If no access token is provided, the plugin will try getting an access token using the details provided in cis_client_id, cis_client_secret, cis_token_url, username, password.
   # This can also be set via the `BTP_CIS_ACCESS_TOKEN` environment variable.
   # cis_access_token = "eyJhbGciOiDBNsO0JxFoAaodkDJ3Pmk7cFEsEr5ml5BwNWEafrEjy8Hsxt2mVACpD8B4AIPpRuMoGE71qXGoPcW0vCugceTwN4C3xM8qYmH7DLQrdVIlSX6kydYxnRNjSO8je56ckA4oTC8wm2E2clClPhinDBN6DxHhXlB0eVJnerl4ONpxaH43PYXmHjIsArTuBGK6nCFtApIGN1OvMDPmjHFtOjNgcPCPC5GDXTt5oaB6M2gUrfD5QQVGA7L6yFQlXYPvF6BSyMxpoQXywMUwYA6oqV"
- 
+
+  # A service key (https://help.sap.com/docs/btp/sap-business-technology-platform/creating-service-keys) for the Central Management Service is required to get an access token.  
+  # The values for cis_client_id, cis_client_secret, cis_token_url can be retrieved from it. 
+
+  # OAuth 2.0 Client ID (field in the service key: uua.clientid). Optional.
+  # This can also be set via the `BTP_CIS_CLIENT_ID` environment variable.
+  # cis_client_id = "sb-ut-6y0m0wr1-ai10-1a56-4bv1-52m478h011g6-clone!b017880|cis-central!b14"
+
+  # OAuth 2.0 Client Secret (field in the service key: uua.clientsecret). Optional.
+  # This can also be set via the `BTP_CIS_CLIENT_SECRET` environment variable. Optional.
+  # cis_client_secret = "44s32264-285r-7101-g2n0-g036p1m214us$vm2_UCHAN_mX1FOW0lklBj2-igBsOUG77G-nE1TWsEu="
+
+  # OAuth 2.0 Token URL (field in the service key: uua.url). Optional.
+  # The value in the service key doesn't contain the path, /oauth/token, if not specified the plugin will append it automatically.
+  # This can also be set via the `BTP_CIS_TOKEN_URL` environment variable. Optional.
+  # cis_token_url = "https://[global-account-subdomain].authentication.[region].hana.ondemand.com"
+
+  # User Email used to log in to SAP BTP.
+  # This can also be set via the `BTP_USERNAME` environment variable. Optional.
+  # username = "user@domain.com"
+
+  # User Password used to log in to SAP BTP.
+  # This can also be set via the `BTP_PASSWORD` environment variable. Optional.
+  # password = "My-BTP-Passw0rd"
 }
 ```
 


### PR DESCRIPTION
The plugin now can authenticate on behalf of a user to get an access token (The access token is also now cached). There is no need to specify lots of variables if a path to the service key is provided. 